### PR TITLE
updated README to change the release commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Publishes all `*.tgz` files from `DIR` to [npmjs](npmjs.com) or [GitHub Packages
 **Usage:**
 
 ```shell
-jsii-release-npm DIR
+npx jsii-release-npm DIR
 ```
 
 **Options (environment variables):**
@@ -41,7 +41,7 @@ Publishes all Maven modules in the `DIR` to [Maven Central](https://search.maven
 **Usage:**
 
 ```shell
-jsii-release-maven DIR
+npx jsii-release-maven DIR
 ```
 
 **Options (environment variables):**
@@ -102,7 +102,7 @@ Publishes all `*.nupkg` to the [NuGet Gallery](https://www.nuget.org/).
 **Usage:**
 
 ```shell
-jsii-release-nuget DIR
+npx jsii-release-nuget DIR
 ```
 
 **Options (environment variables):**
@@ -118,7 +118,7 @@ Publishes all `*.whl` files to [PyPI](https://pypi.org/).
 **Usage:**
 
 ```shell
-jsii-release-pypi DIR
+npx jsii-release-pypi DIR
 ```
 
 **Options (environment variables):**


### PR DESCRIPTION
*Description of changes:*
updated README to change the release commands from 'jsii-release-*' into 'npx jsii-release-*'

Not sure if this is just me/my CircleCI setup, but I was getting `command not found` on the `jsii-release-*` commands (as can be seen [here](https://app.circleci.com/jobs/github/kollavarsham/kollavarsham-js/43)).

Changing the commands to `npx jsii-release-*` [helped](https://app.circleci.com/jobs/github/kollavarsham/kollavarsham-js/48/parallel-runs/0/steps/0-106) resolve this issue.


------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
