### PR TITLE
fix(jsii-release-npm): support publishing to AWS CodeArtifact NPM repository

### DIFF
--- a/bin/jsii-release-npm
+++ b/bin/jsii-release-npm
@@ -22,7 +22,7 @@ if [ -z "${NPM_TOKEN:-}" ]; then
 fi
 
 NPM_REGISTRY=${NPM_REGISTRY:-"registry.npmjs.org"}
-echo "//${NPM_REGISTRY}/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+echo "//${NPM_REGISTRY%%/}/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 # this overrides any registry configuration defined externally. For example, yarn sets the registry to the yarn proxy
 # which requires `yarn login`. but since we are logging in through ~/.npmrc, we must make sure we publish directly to npm.


### PR DESCRIPTION
fix(jsii-release-npm): support publishing to AWS CodeArtifact NPM repository
Closes #3 

The NPM registry from AWS CodeArtifact comes with a trailing /, which creates the value of `NPM_REGISTRY` with double slash in .npmrc. This PR strips off the additional slash to make it work with AWS CodeArtifact.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
