### PR TITLE
fix: dont quote list variable

### DIFF
--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -127,7 +127,7 @@ echo " Preparing repository"
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
 # Sign and stage our artifacts into a local directory
-for pom in "${poms}"; do
+for pom in ${poms}; do
     $mvn --settings=${mvn_settings} gpg:sign-and-deploy-file                    \
         -Durl=file://${staging}                                                 \
         -DrepositoryId=maven-central                                            \


### PR DESCRIPTION
When multiple `*.pom` files exist under `dist/java`, i.e there are multiple packages to publish, the script does not iterate over all files and actually produces a single corrupted command.

Example:

```console
mvn --settings=/tmp/tmp.qeJue3YKgn/mvn-settings.xml gpg:sign-and-deploy-file -Durl=file:///tmp/tmp.FWzIxZoO74 -DrepositoryId=maven-central -Dgpg.homedir=/tmp/tmp.6ZGZGUow9z -Dgpg.keyname=0x28A12317239E021D -Dgpg.passphrase=*** -DpomFile=./org/***/***/0.25.0/***-0.25.0.pom ./org/***/***-plus/0.25.0/***-plus-0.25.0.pom -Dfile=./org/***/***/0.25.0/***-0.25.0.jar ./org/***/***-plus/0.25.0/***-plus-0.25.0.pom -Dsources=./org/***/***/0.25.0/***-0.25.0-sources.jar ./org/***/***-plus/0.25.0/***-plus-0.25.0.pom -Djavadoc=./org/***/***/0.25.0/***-0.25.0-javadoc.jar ./org/***/***-plus/0.25.0/***-plus-0.25.0.pom
```

This flusters maven and eventually causes it to think there is no pom file defined:

```console
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.063 s
[INFO] Finished at: 2020-06-22T15:45:56Z
[INFO] ------------------------------------------------------------------------
[ERROR] The goal you specified requires a project to execute but there is no POM in this directory (/__w/***/***/dist/java). Please verify you invoked Maven from the correct directory. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MissingProjectException
##[error]Process completed with exit code 1.
```

The root cause is the quoting of the list variable in the `in` loop, causing it to run only once, treating the entire list of strings as a single, multiline string.

Not being a bash expert, i'm not sure exactly why this happens, I imagine its something specific with `in` loops.

In any case, removing the quote seems harmless and resolves the problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
