### PR TITLE
fix: quote query in find command

### DIFF
--- a/bin/jsii-release-nuget
+++ b/bin/jsii-release-nuget
@@ -21,7 +21,7 @@ if [ -z "${NUGET_API_KEY:-}" ]; then
     exit 1
 fi
 
-packages=$(find . -name *.nupkg -not -iname *.symbols.nupkg)
+packages=$(find . -name '*.nupkg' -not -iname '*.symbols.nupkg')
 if [ -z "${packages}" ]; then
     echo "❌ No *.nupkg files found under $PWD. Nothing to publish"
     exit 1


### PR DESCRIPTION
The `*` in the query is subject to bash expansion which messes up the invocation. 

```console
find: paths must precede expression: Org.Cdk8s.Plus.0.25.0.nupkg
Usage: find [-H] [-L] [-P] [-Olevel] [-D help|tree|search|stat|rates|opt|exec] [path...] [expression]
##[error]Process completed with exit code 1.
```

Quote the query so that it doesn't undergo expansion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
